### PR TITLE
class node, dictionary of channels availability

### DIFF
--- a/Lab3.ipynb
+++ b/Lab3.ipynb
@@ -88,6 +88,7 @@
     "        self._position= node_dict ['position']\n",
     "        self._connected_nodes= node_dict ['connected_nodes']\n",
     "        self._successive= {}\n",
+    "        self._switching_matrix= None\n",
     "\n",
     "    @property\n",
     "    def label (self):\n",
@@ -111,7 +112,7 @@
     "\n",
     "    @successive.setter\n",
     "    def successive (self, successive ):\n",
-    "        self._successive = successive\n",
+    "        self._successive = successive  \n",
     "\n",
     "    def propagate (self, signal_information):\n",
     "        path= signal_information.path\n",
@@ -120,7 +121,15 @@
     "            line= self.successive [line_label]\n",
     "            signal_information.next () # scroll the nodes up to the last one\n",
     "            signal_information= line.propagate (signal_information)\n",
-    "        return signal_information"
+    "        return signal_information\n",
+    "    \n",
+    "    @property\n",
+    "    def switching_matrix (self): # link the node to the next one\n",
+    "        return self._switching_matrix\n",
+    "\n",
+    "    @switching_matrix.setter\n",
+    "    def switching_matrix (self, switch_mat ):\n",
+    "        self._switching_matrix = switch_mat"
    ]
   },
   {


### PR DESCRIPTION
we add a dictionary for the switching matrix that for each couple of connected_node it stores the 10 channels availability (OCCUPIED = 0, FREE = 1) for now switching_matrix [ii][ii]=0 (to avoid loops) and 1 for the others, no need for updates during the run.
In the method route_space we multiply the path availability through lines times the blockage of each node of the path (= switching_matrix [’in_node ’][ ’out_node ’])